### PR TITLE
Feat: get channel members and mention them before archive

### DIFF
--- a/main.py
+++ b/main.py
@@ -74,9 +74,14 @@ def list_channel(threshold_days, send_message, save_path, dry_run):
     default=100,
     help="Days of condition to archive inactive channels",
 )
+@click.option(
+    "--list-members",
+    is_flag=True,
+    help="If True, Get a list of channel members and mention them before archive",
+)
 @click.option("--dry-run", is_flag=True)
 @cli.command("archive")
-def archive_channel(threshold_days, dry_run):
+def archive_channel(threshold_days, dry_run, list_members):
     """archive channels that bot joined
 
     * If the channels is active, leave the channel without archive

--- a/src/archive.py
+++ b/src/archive.py
@@ -5,6 +5,7 @@ from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
 from src.channel_analytics import is_not_active_channels
+from src.send_message import send_mention_message
 
 
 def run_conversations_list(
@@ -129,7 +130,7 @@ def archive_channels(
             continue
         if is_not_active_channels(latest_ts, threshold_days, target_dt=target_dt):
             if not dry_run:
-                # todo list members before archive
+                send_mention_message(client, channel_info["id"])
                 try:
                     client.conversations_archive(channel=channel_info["id"])
                 except SlackApiError as e:

--- a/src/archive.py
+++ b/src/archive.py
@@ -102,6 +102,7 @@ def archive_channels(
     threshold_days: int,
     target_dt: datetime = None,
     dry_run: bool = True,
+    list_message: bool = False,
 ):
     """archive channels that bot joined
     If the channel become active, bot leave from it.
@@ -110,6 +111,7 @@ def archive_channels(
         client: slack_sdk WebClient
         threshold_days: Days of condition to archive inactive channels
         dry_run: if True, only check if each channel that bot joined is inactive
+        list_message: list channel members and mention them before archive
 
     Return:
         channel info list
@@ -130,7 +132,8 @@ def archive_channels(
             continue
         if is_not_active_channels(latest_ts, threshold_days, target_dt=target_dt):
             if not dry_run:
-                send_mention_message(client, channel_info["id"])
+                if list_message:
+                    send_mention_message(client, channel_info["id"])
                 try:
                     client.conversations_archive(channel=channel_info["id"])
                 except SlackApiError as e:

--- a/src/channel_members.py
+++ b/src/channel_members.py
@@ -21,7 +21,7 @@ class SlackChannelMembers:
                 cursor = response.get("response_metadata", {}).get("next_cursor")
                 if not cursor:
                     break
-            return members_list
+            return sorted(members_list)
         except SlackApiError as e:
             print(f"Error fetching members: {e.response['error']}")
             return []

--- a/src/channel_members.py
+++ b/src/channel_members.py
@@ -1,0 +1,51 @@
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+
+
+class SlackChannelMembers:
+    def __init__(self, client: WebClient):
+        self.client = client
+
+    def get_user_ids_in_channel(self, channel_id: str) -> list[str]:
+        """get user ids in channel"""
+        try:
+            members_list = []
+            cursor = None
+            while True:
+                response = self.client.conversations_members(
+                    channel=channel_id, cursor=cursor, limit=200
+                )
+                members = response.get("members")
+                if members:
+                    members_list.extend(members)
+                cursor = response.get("response_metadata", {}).get("next_cursor")
+                if not cursor:
+                    break
+            return members_list
+        except SlackApiError as e:
+            print(f"Error fetching members: {e.response['error']}")
+            return []
+
+    @staticmethod
+    def convert_id_to_mention(user_id: str) -> str:
+        return f"<@{user_id}>"
+
+    def get_mentions_in_channel(self, channel_id: str) -> list[str]:
+        """get user ID list with format
+
+        Return:
+            mention syntaxed user id list
+            e.g. ["<@U012AB3CD>","<@U345AB6CD>"]
+        """
+        user_ids = self.get_user_ids_in_channel(channel_id)
+        return [self.convert_id_to_mention(user_id) for user_id in user_ids]
+
+    def build_mentions_blocks(self, channel_id: str) -> list[dict]:
+        """create mention list as Slack Blocks"""
+        mentions = self.get_mentions_in_channel(channel_id)
+        if not mentions:
+            text = "There are no members in this channel."
+        else:
+            text = "\n".join(mentions)
+        blocks = [{"type": "section", "text": {"type": "mrkdwn", "text": text}}]
+        return blocks

--- a/src/send_message.py
+++ b/src/send_message.py
@@ -3,6 +3,8 @@
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 
+from src.channel_members import SlackChannelMembers
+
 
 def send_text(client: WebClient, channel_id: str, blocks: list):
     """https://api.slack.com/methods/chat.postMessage
@@ -18,7 +20,7 @@ def send_text(client: WebClient, channel_id: str, blocks: list):
 
 
 def format_notice_message(channel_name: str, days: int) -> list:
-    """create massege
+    """create message
     todo set template text
     """
     message = (
@@ -31,6 +33,19 @@ def format_notice_message(channel_name: str, days: int) -> list:
             "text": message,
         },
     ]
+
+
+def send_mention_message(client: WebClient, channel_id: str):
+    """mention channel members before archive"""
+    members_helper = SlackChannelMembers(client)
+    mention_blocks = members_helper.build_mentions_blocks(channel_id=channel_id)
+    blocks = [
+        {
+            "type": "markdown",
+            "text": "# Information\n投稿がないため、このチャンネルはアーカイブされます。",
+        }
+    ] + mention_blocks
+    send_text(client, channel_id, blocks=blocks)
 
 
 def join_channels(

--- a/tests/test_channel_members.py
+++ b/tests/test_channel_members.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest.mock import patch
+from slack_sdk import WebClient
+from src.channel_members import SlackChannelMembers
+
+
+class TestSlackChannelMembers(unittest.TestCase):
+    def setUp(self):
+        mock_client = WebClient()
+        self.channel_id = "CHANNEL_ID"
+        self.helper = SlackChannelMembers(client=mock_client)
+
+    @patch.object(WebClient, "conversations_members")
+    def test_get_user_ids_in_channel(self, mock_conversations_members):
+        # モックレスポンスを定義（ページネーションなし）
+        mock_conversations_members.return_value = {
+            "ok": True,
+            "members": ["U111", "U222", "U333"],
+            "response_metadata": {"next_cursor": ""},
+        }
+
+        user_ids = self.helper.get_user_ids_in_channel(self.channel_id)
+        self.assertEqual(user_ids, ["U111", "U222", "U333"])
+        mock_conversations_members.assert_called_once_with(
+            channel=self.channel_id, cursor=None, limit=200
+        )
+
+    def test_convert_id_to_mention(self):
+        cases = [["U012AB3CD", "<@U012AB3CD>"], ["U345AB6CD", "<@U345AB6CD>"]]
+        for uid, expected in cases:
+            with self.subTest(uid=uid, expected=expected):
+                result = self.helper.convert_id_to_mention(uid)
+                self.assertEqual(result, expected)
+
+    @patch.object(SlackChannelMembers, "get_user_ids_in_channel")
+    def test_get_mentions_in_channel(self, mock_get_user_ids):
+        mock_get_user_ids.return_value = ["U111", "U222"]
+        mentions = self.helper.get_mentions_in_channel(self.channel_id)
+        self.assertEqual(mentions, ["<@U111>", "<@U222>"])
+
+    @patch.object(SlackChannelMembers, "get_mentions_in_channel")
+    def test_build_mentions_blocks_with_users(self, mock_get_mentions):
+        mock_get_mentions.return_value = ["<@U111>", "<@U222>"]
+
+        blocks = self.helper.build_mentions_blocks(self.channel_id)
+        self.assertEqual(blocks[0]["type"], "section")
+        self.assertDictEqual(
+            {"type": "mrkdwn", "text": "<@U111>\n<@U222>"}, blocks[0]["text"]
+        )
+
+    @patch.object(SlackChannelMembers, "get_mentions_in_channel")
+    def test_build_mentions_blocks_empty(self, mock_get_mentions):
+        mock_get_mentions.return_value = []
+
+        blocks = self.helper.build_mentions_blocks(self.channel_id)
+        self.assertIn(
+            "There are no members in this channel.", blocks[0]["text"]["text"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- [x] `src/channel_members.py`: channel members の取得
- [x] `send_mention_message`: channel members へのメンションメッセージを送信
- [x] *archive_channel* add option `--list-members` ↑の機能を有効化するフラグ追加
- [x] fix `get_latest_message_ts`: slack archive bot の投稿は skip
